### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -208,7 +208,7 @@ def stop_bot():
                    return jsonify({"status": "Stop signal sent, acknowledgement timeout."}), 202
              except Exception as e:
                    ui_logger.error("Error occurred while trying to stop the bot: %s", e, exc_info=True)
-                   return jsonify({"status": "Error signaling stop", "error": str(e)}), 500
+                   return jsonify({"status": "Error signaling stop"}), 500
         elif bot_state.is_running:
              # Bot is marked as running, but core/loop might be missing (error state?)
              ui_logger.warning("Stop requested, but bot state is inconsistent (running=True, but core/loop missing). Forcing state update.")


### PR DESCRIPTION
Potential fix for [https://github.com/John0n1/ON1Builder/security/code-scanning/1](https://github.com/John0n1/ON1Builder/security/code-scanning/1)

To fix the issue, we should avoid including the raw exception message (`str(e)`) in the response sent to the user. Instead, we can log the exception details on the server for debugging purposes and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to diagnose issues using server logs.

The changes required are:
1. Replace the JSON response on line 211 to exclude the exception message.
2. Log the exception details using `ui_logger.error` to retain debugging information on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
