### PR TITLE
Potential fix for code scanning alert no. 20: Clear-text logging of sensitive information

### DIFF
--- a/scripts/python/app_multi_chain.py
+++ b/scripts/python/app_multi_chain.py
@@ -381,7 +381,7 @@ def simulate_transaction() -> Dict[str, Any]:
         logger.error(f"Error simulating transaction: {e}")
         return jsonify({
             "status": "error",
-            "message": f"Error simulating transaction: {str(e)}",
+            "message": "An internal error occurred while simulating the transaction.",
         }), 500
 
 # Main function

--- a/scripts/python/configuration_multi_chain.py
+++ b/scripts/python/configuration_multi_chain.py
@@ -292,7 +292,7 @@ class MultiChainConfiguration(types.SimpleNamespace):
                             secret_key = f"CHAIN_{chain_id}_{key}"
                             secret_value = _get_vault_secret(vault_addr, vault_token, chain_path, key)
                             if secret_value:
-                                logger.info(f"Loaded {secret_key} from Vault")
+                                logger.info("Loaded a secret for a chain-specific key from Vault")
                                 data[secret_key] = secret_value
             else:
                 logger.warning("VAULT_ADDR or VAULT_TOKEN not set, skipping Vault secret loading")


### PR DESCRIPTION
Potential fix for [https://github.com/John0n1/ON1Builder/security/code-scanning/20](https://github.com/John0n1/ON1Builder/security/code-scanning/20)

To fix the issue, we should avoid logging sensitive information, including key names that could reveal details about the system's configuration. Instead, we can log a generic message indicating that secrets were successfully loaded without specifying the key names. This approach ensures that no sensitive information is exposed while still providing useful debugging information.

The changes involve:
1. Replacing the log message on line 295 with a generic message that does not include `secret_key`.
2. Ensuring that no sensitive information is inadvertently logged elsewhere in the same context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
