### PR TITLE
Potential fix for code scanning alert no. 19: Clear-text logging of sensitive information

### DIFF
--- a/scripts/python/app_multi_chain.py
+++ b/scripts/python/app_multi_chain.py
@@ -327,10 +327,10 @@ def test_alert() -> Dict[str, Any]:
             "message": "Test alert sent",
         })
     except Exception as e:
-        logger.error(f"Error sending test alert: {e}")
+        logger.error(f"Error sending test alert: {e}", exc_info=True)
         return jsonify({
             "status": "error",
-            "message": f"Error sending test alert: {str(e)}",
+            "message": "An internal error occurred while sending the test alert.",
         }), 500
 
 # Simulate transaction endpoint

--- a/scripts/python/configuration_multi_chain.py
+++ b/scripts/python/configuration_multi_chain.py
@@ -279,7 +279,7 @@ class MultiChainConfiguration(types.SimpleNamespace):
                 for key in _SECRET_KEYS:
                     secret_value = _get_vault_secret(vault_addr, vault_token, vault_path, key)
                     if secret_value:
-                        logger.info(f"Loaded {key} from Vault")
+                        logger.info("Loaded a secret from Vault")
                         data[key] = secret_value
                 
                 # Load chain-specific secrets
@@ -292,7 +292,7 @@ class MultiChainConfiguration(types.SimpleNamespace):
                             secret_key = f"CHAIN_{chain_id}_{key}"
                             secret_value = _get_vault_secret(vault_addr, vault_token, chain_path, key)
                             if secret_value:
-                                logger.info("Loaded a secret for a chain-specific key from Vault")
+                                logger.info("Loaded a chain-specific secret from Vault")
                                 data[secret_key] = secret_value
             else:
                 logger.warning("VAULT_ADDR or VAULT_TOKEN not set, skipping Vault secret loading")


### PR DESCRIPTION
Potential fix for [https://github.com/John0n1/ON1Builder/security/code-scanning/19](https://github.com/John0n1/ON1Builder/security/code-scanning/19)

To fix the issue, we should avoid logging sensitive key names directly. Instead, we can log a generic message indicating that a secret was loaded without specifying the key name. This ensures that no sensitive information is exposed in the logs while still providing useful debugging information.

The fix involves replacing the line `logger.info(f"Loaded {key} from Vault")` with a more generic log message, such as `logger.info("Loaded a secret from Vault")`. This change ensures that sensitive key names are not exposed in the logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
